### PR TITLE
Rename dispatch to encode + add decode

### DIFF
--- a/example.js
+++ b/example.js
@@ -48,7 +48,7 @@ ns2.register({
 // Write the hyperdispatch configuration to disk
 Hyperdispatch.toDisk(hyperdispatch)
 
-const { Router, dispatch } = require('./spec/hyperdispatch')
+const { Router, encode } = require('./spec/hyperdispatch')
 
 const router = new Router()
 
@@ -71,9 +71,9 @@ router.add('@example/command3', (data, context) => {
 const context = { user: 'exampleUser' }
 
 // Dispatch a command1 message
-const encodedMessage1 = dispatch('@example/command1', { field1: 42, field2: 'hello' })
+const encodedMessage1 = encode('@example/command1', { field1: 42, field2: 'hello' })
 router.dispatch(encodedMessage1, context)
 
 // Dispatch a command3 message
-const encodedMessage2 = dispatch('@example/command3', { field1: 'world', field2: 99 })
+const encodedMessage2 = encode('@example/command3', { field1: 'world', field2: 99 })
 router.dispatch(encodedMessage2, context)

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -69,32 +69,46 @@ module.exports = function generateCode (hyperdispatch, { esm = false }) {
 
   str += '\n'
 
-  str += 'function dispatch (name, message, { version = defaultVersion } = {}) {\n'
+  str += 'function encode (name, message, { version = defaultVersion } = {}) {\n'
   str += '  const state = { buffer: null, start: 0, end: 0 }\n'
   str += '\n'
-  str += '  const o = getEncoderAndId(name)\n'
+  str += '  const route = getRouteByName(name)\n'
   str += '  setVersion(version)\n'
   str += '\n'
-  str += '  c.uint.preencode(state, o.id)\n'
-  str += '  o.enc.preencode(state, message)\n'
+  str += '  c.uint.preencode(state, route.id)\n'
+  str += '  route.enc.preencode(state, message)\n'
   str += '\n'
   str += '  state.buffer = b4a.allocUnsafe(state.end)\n'
-  str += '  c.uint.encode(state, o.id)\n'
-  str += '  o.enc.encode(state, message)\n'
+  str += '  c.uint.encode(state, route.id)\n'
+  str += '  route.enc.encode(state, message)\n'
   str += '\n'
   str += '  return state.buffer\n'
   str += '}\n'
   str += '\n'
 
+  str += 'function decode (buffer, { version = defaultVersion } = {}) {\n'
+  str += '  const state = { buffer, start: 0, end: buffer.length }\n'
+  str += '\n'
+  str += '  const id = c.uint.decode(state)\n'
+  str += '  const route = getRouteById(id)\n'
+  str += '  setVersion(version)\n'
+  str += '\n'
+  str += '  const value = route.enc.decode(state)'
+  str += '\n'
+  str += '  return { name: route.name, value }\n'
+  str += '}\n'
+  str += '\n'
+
   for (const handler of hyperdispatch.handlers) {
     str += 'const route' + handler.id + ' = {\n'
+    str += `  name: ${s(handler.name)},\n`
     str += `  id: ${handler.id},\n`
     str += `  enc: getEncoding(${s(handler.requestType)})\n`
     str += '}\n'
     str += '\n'
   }
 
-  str += 'function getEncoderAndId (name) {\n'
+  str += 'function getRouteByName (name) {\n'
   str += '  switch (name) {\n'
   for (const handler of hyperdispatch.handlers) {
     str += `    case ${s(handler.name)}:\n`
@@ -104,19 +118,32 @@ module.exports = function generateCode (hyperdispatch, { esm = false }) {
   str += '      throw new Error(\'Handler not found for name: \' + name)\n'
   str += '  }\n'
   str += '}\n'
+  str += '\n'
 
+  str += 'function getRouteById (id) {\n'
+  str += '  switch (id) {\n'
+  for (const handler of hyperdispatch.handlers) {
+    str += `    case ${handler.id}:\n`
+    str += `      return route${handler.id}\n`
+  }
+  str += '    default:\n'
+  str += '      throw new Error(\'Handler not found for ID: \' + id)\n'
+  str += '  }\n'
+  str += '}\n'
   str += '\n'
 
   if (esm) {
     str += 'export {\n'
     str += '  version,\n'
-    str += '  dispatch,\n'
+    str += '  encode,\n'
+    str += '  decode,\n'
     str += '  Router\n'
     str += '}\n'
   } else {
     str += 'module.exports = {\n'
     str += '  version,\n'
-    str += '  dispatch,\n'
+    str += '  encode,\n'
+    str += '  decode,\n'
     str += '  Router\n'
     str += '}\n'
   }

--- a/test/basic.js
+++ b/test/basic.js
@@ -36,7 +36,7 @@ test('basic sync switch', async t => {
       })
     }
   })
-  const { dispatch, Router } = hd.module
+  const { encode, Router } = hd.module
 
   const r = new Router()
   r.add('@test/test-request-1', (req, ctx) => {
@@ -50,8 +50,8 @@ test('basic sync switch', async t => {
     t.is(req.str, 'world')
   })
 
-  await r.dispatch(dispatch('@test/test-request-1', { id: 10, str: 'hello' }), 'some-context')
-  await r.dispatch(dispatch('@test/test-request-2', { id: 20, str: 'world' }), 'another-context')
+  await r.dispatch(encode('@test/test-request-1', { id: 10, str: 'hello' }), 'some-context')
+  await r.dispatch(encode('@test/test-request-2', { id: 20, str: 'world' }), 'another-context')
 })
 
 test('basic sync switch + offset', async t => {
@@ -85,10 +85,10 @@ test('basic sync switch + offset', async t => {
       })
     }
   }, { offset: 10 })
-  const { dispatch } = hd.module
+  const { encode } = hd.module
 
-  const msg1 = dispatch('@test/test-request-1', { id: 10, str: 'hello' })
-  const msg2 = dispatch('@test/test-request-2', { id: 10, str: 'world' })
+  const msg1 = encode('@test/test-request-1', { id: 10, str: 'hello' })
+  const msg2 = encode('@test/test-request-2', { id: 10, str: 'world' })
   t.is(c.decode(c.uint, msg1), 10)
   t.is(c.decode(c.uint, msg2), 11)
 })


### PR DESCRIPTION
Renamed the exported `dispatch` function to `encode` (more descriptive, but breaking change). Also added a corresponding `decode` which returns an object of the form `{ name, value }`.