### PR TITLE
FIX: Hyperdispatch.from in normal usage does not set { offset } in opts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# example.js spec folder
+/spec

--- a/builder.cjs
+++ b/builder.cjs
@@ -22,7 +22,7 @@ class HyperdispatchNamespace {
 
 module.exports = class Hyperdispatch {
   constructor (schema, dispatchJson, { offset, dispatchDir = null, schemaDir = null } = {}) {
-    if (dispatchJson && dispatchJson.offset !== offset) {
+    if (dispatchJson && offset && dispatchJson.offset !== offset) {
       throw new Error('Cannot change the hyperdispatch offset once it has been defined once')
     }
     this.schema = schema

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     }
   },
   "scripts": {
-    "test": "standard && brittle test/index.js"
+    "test": "standard && brittle test/index.js && npm run example:rebuild",
+    "example:rebuild": "node example.js && node example.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Running the example.js file twice would throw the following error

`
/Users/ryan/github/holepunch/hyperdispatch/builder.cjs:27
      throw new Error('Cannot change the hyperdispatch offset once it has been defined once')
      ^
`
This was because the offset in the json was 0, but the opts when using the Hyperdispatch.from would be undefined in normal world usage.

This fix 
 
 - makes sure that offset is defined before doing the offest comparison
 - runs example.js twice in normal usage as part of the npm test to ensure normal rebuilding works
 - excludes the spec folder from git 
