### PR TITLE
fix test on bare

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,14 @@
     "fs/*": {
       "bare": "bare-fs/*",
       "default": "fs/*"
+    },
+    "process": {
+      "bare": "bare-process",
+      "default": "process"
+    },
+    "child_process": {
+      "bare": "bare-subprocess",
+      "default": "child_process"
     }
   },
   "exports": {
@@ -51,6 +59,8 @@
   },
   "homepage": "https://github.com/holepunchto/hyperdispatch#readme",
   "devDependencies": {
+    "bare-process": "^4.2.2",
+    "bare-subprocess": "^5.2.2",
     "brittle": "^3.7.0",
     "prettier": "^3.6.2",
     "prettier-config-holepunch": "^2.0.0",


### PR DESCRIPTION
Fix dependencies to test for bare

Tests pass with `node test/index.js` but fail with `bare test/index.js`:

```
# basic two namespaces with interleaved op additions
Uncaught (in promise) Error: Cannot register a handler for a nonexistent route: @test1/test-request-3
    at Router.add (file:///Users/thangnv/Develop/holepunchto/Hyperdispatch/test/test-storage/tmp-test-bf76fc1decddc8/hyperdispatch/index.js:26:15)
    at file:///Users/thangnv/Develop/holepunchto/Hyperdispatch/test/basic.js:227:5
    at async Test._run (file:///Users/thangnv/Develop/holepunchto/Hyperdispatch/node_modules/brittle/index.js:597:7)
```