### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "b4a": "^1.6.7",
     "bare-fs": "^4.2.3",
     "bare-path": "^3.0.0",
-    "compact-encoding": "^2.16.0",
+    "compact-encoding": "^3.0.0",
     "generate-string": "^1.0.1",
     "hyperschema": "^1.3.2",
     "nanoassert": "^2.0.0"


### PR DESCRIPTION
Depends on:
- https://github.com/holepunchto/hyperschema/pull/56